### PR TITLE
Add Typed Promises (in Data.JSVal.Typed.Promise) that enforce the type of a variable to be awaited

### DIFF
--- a/ghcjs-promise.cabal
+++ b/ghcjs-promise.cabal
@@ -15,10 +15,13 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   js-sources:          src/js/promise_functions.js
-  exposed-modules:     Data.JSVal.Promise
+  exposed-modules:     Data.JSVal.Promise,
+                       Data.JSVal.Typed.Promise
   build-depends:       base >= 4.7 && < 5
                      , ghcjs-base
                      , protolude
+                     , either
+                     , mtl
 
   default-language:    Haskell2010
 

--- a/src/Data/JSVal/Typed/Promise.hs
+++ b/src/Data/JSVal/Typed/Promise.hs
@@ -1,0 +1,42 @@
+module Data.JSVal.Typed.Promise (
+  Promise,
+  await,
+  awaitMaybe,
+  AwaitError(..)
+) where
+
+import Protolude (maybeToRight)
+import Control.Monad.Except (ExceptT(..), runExceptT)
+import Data.Either.Combinators (rightToMaybe, mapLeft)
+import qualified Data.JSVal.Promise as P
+
+import GHCJS.Types
+import GHCJS.Marshal
+
+-- | A Typed Promise is tagged with the expected type of the eventual value.
+--   We don't export the constructor or field accessor, so the user must provide a
+--   `FromJSVal` instance when awaiting the value.
+--
+--   This allows an inline Javascript function to return @Promise a@ and enforce
+--   type safety in the return. @Promise@ is a newtype around @JSVal@ so is valid
+--   to be passed through Javascript FFI.
+newtype Promise a = Promise JSVal
+
+instance IsJSVal (Promise a)
+
+data AwaitError = InvalidType
+                | PromiseErr JSVal
+
+-- | Await a value and attempt to cast into the correct return type.
+await :: FromJSVal a => Promise a -> IO (Either AwaitError a)
+await (Promise js) = runExceptT $ do
+  untyped <- fromJSVal' js
+  p <- ExceptT $ mapLeft PromiseErr <$> P.await untyped
+  fromJSVal' p
+
+-- | Suppress error messages and just return a `Maybe` for convenience.
+awaitMaybe :: FromJSVal a => Promise a -> IO (Maybe a)
+awaitMaybe p = rightToMaybe <$> await p
+
+fromJSVal' :: FromJSVal a => JSVal -> ExceptT AwaitError IO a
+fromJSVal' j = ExceptT $ maybeToRight InvalidType <$> fromJSVal j

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,18 +1,16 @@
-resolver: nightly-2016-10-25
+resolver: lts-8.11
 packages:
 - '.'
 
-
-
-compiler: ghcjs-0.2.1.820161025_ghc-8.0.1
-compiler-check: match-exact  
+compiler: ghcjs-0.2.1.9008011_ghc-8.0.2
+compiler-check: match-exact
 
 setup-info:
   ghcjs:
     source:
-      ghcjs-0.2.1.820161025_ghc-8.0.1:
-          url: http://tolysz.org/ghcjs/untested/ghc-8.0-2016-10-25-nightly-2016-10-25-820161025.tar.gz
-          sha1: ca05f23ab6af89803a9fa8ce7241ebdd2eee7dae
+      ghcjs-0.2.1.9008011_ghc-8.0.2:
+        url: https://github.com/matchwood/ghcjs-stack-dist/raw/master/ghcjs-0.2.1.9008011.tar.gz
+        sha1: a72a5181124baf64bcd0e68a8726e65914473b3b
 
 extra-deps: []
 


### PR DESCRIPTION
We've been using your ghcjs-promise library and it's been great; however, not being able to define the promise value type when defining the inline JS functions was a bit of a worry, as it would be nice to enforce that.

To do so, I've added a new module that adds typed promises, where promises are parameterized with their eventual value type. Then, when you await a typed promise, we also perform the correct conversion (assuming it is available), enforcing type safety in the code of anyone calling the inline JS.

I'd love to be able to contribute this back upstream to your library.

Let me know if you have any feedback or suggestions.